### PR TITLE
fix: Can't go back to the root page after invoke setState()

### DIFF
--- a/lib/src/stateful_widget.dart
+++ b/lib/src/stateful_widget.dart
@@ -52,7 +52,8 @@ abstract class StateWidget<T extends StatefulWidget> {
     if (!mounted) {
       throw Exception(
           "Tried to call setState on a $runtimeType Widget which is not mounted!");
-    } else if (context.child?.element?.isConnected != true) {
+    } else if (context.child?.element?.isConnected != true &&
+        context.widget.runtimeType != BasicRouter) {
       throw Exception(
           "Tried to call setState on a $runtimeType Widget while the child is not connected!");
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wupper
 description: Dart Web UI Framework based on HTML Elements inspired by Flutter
-version: 5.0.6
+version: 5.0.7
 homepage: https://famedly.com
 repository: https://github.com/famedly/wupper
 issue_tracker: https://github.com/famedly/wupper/issues


### PR DESCRIPTION
https://github.com/famedly/wupper/issues/7
I've made some attempts to circumvent this error, but I'm sure there's a more elegant way to handle it.